### PR TITLE
Refactor/packager

### DIFF
--- a/examples/react-next/app/page.tsx
+++ b/examples/react-next/app/page.tsx
@@ -4,7 +4,6 @@ import {ComponentAPI} from '@/components/PropTable';
 import docs from '!doc!@/components/ExampleComponents';
 
 export default function Home() {
-  console.log(docs);
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div>

--- a/examples/react-next/app/page.tsx
+++ b/examples/react-next/app/page.tsx
@@ -1,15 +1,15 @@
 'use client';
 
-import {ComponentAPI, PropTable} from '@/components/PropTable';
-import docs from '!doc!@/components/PropTable';
-import {TypeContext} from '@faulty/ts-docs-type-renderer/react';
+import {ComponentAPI} from '@/components/PropTable';
+import docs from '!doc!@/components/ExampleComponents';
 
 export default function Home() {
+  console.log(docs);
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <div>
         <h1 className="text-xl font-bold mb-8">ComponentAPI</h1>
-        <ComponentAPI docs={docs} componentName="ComponentAPI" />
+        <ComponentAPI docs={docs} componentName="ExampleInput" />
       </div>
     </main>
   );

--- a/examples/react-next/components/ExampleComponents.tsx
+++ b/examples/react-next/components/ExampleComponents.tsx
@@ -1,0 +1,153 @@
+import {ComponentType} from 'react';
+
+/**
+ * React Native Input components have a broad set of properties to control them,
+ * some of which we do not want to inherit (onChange) or expose to consumers of
+ * the design system (style). Omitting these props from a native component's
+ * props will ensure that the resulting interface does not leak any of those
+ * unwanted props to consumers.
+ *
+ * Other inputs may have additional props to omit based on the type of native
+ * input component being used, in which case they should use this type as a
+ * union with all of the other props to omit.
+ */
+export type DisallowedNativeInputProps =
+  // We want to enforce strict styling on inputs themselves, so consumers are not
+  // able to override any styles on inputs.
+  | 'style'
+  // We are forgoing react-native's default event handlers, which provide the
+  // event as the argument for `onChange` and use a secondary callback,
+  // `onChangeText`, to provide the text value directly.
+  // Instead, for simplicity and convenience, we are making `onChange` act like
+  // `onChangeText` and provide the text value rather than the event. This
+  // appears to be a safe behavior, as in our entire native codebase, there are
+  // only a few handlers that even read the event in the first place, and even
+  // those only use it to retrieve the textual value.
+  // This also lets non-textual inputs have a consistent API, using
+  // `onChange(value: T)` to provide any relevant data type without having to
+  // use a different callback name.
+  | 'onChange'
+  | 'onChangeText'
+  // Similarly, we define `value` directly using `InputValueProps` to let it
+  // take on different data types
+  | 'defaultValue'
+  | 'value';
+
+export interface InputValueProps<T> {
+  /**
+   * Initial value to use for the input. Setting this will allow the input
+   * value to change without needing to update it through controlled state.
+   */
+  defaultValue?: T;
+  /** When given, controls the value of the input. If omitted, the input is
+   * considered "uncontrolled". It will still function and fire callbacks as
+   * expected, but without the need for the consumer to provide the value.
+   *
+   * Uncontrolled inputs can still provide an initial value to set on the
+   * input by using the `defaultValue` prop. */
+  value?: T;
+  /**
+   * Called as soon as the value of the input changes. For textual inputs, this
+   * happens on every entry or deletion while the user is editing the value. For
+   * picker-based inputs, this happens when the user selects a value.
+   * Note that the argument to the callback is the value of the input directly,
+   * rather than the change event that was fired.
+   */
+  onChange?: (value: T) => void;
+}
+
+/**
+ * Common interface for querying and manipulating the state of an input. Each
+ * input type should extend this interface for whatever value type it contains,
+ * and provide any additional useful methods for interacting with its value.
+ */
+export interface InputState {
+  /** Whether the input currently has a non-empty value. */
+  hasValue: boolean;
+  /** Set the textual value of the input and call `onChange` */
+  setTextValue: (value: string) => void;
+  /** Set the text value of the input to an empty string and call `onClear`. */
+  clear: () => void;
+}
+
+/** Props related to making an input immediately clearable. */
+export interface ClearableProps {
+  /** Whether the input can be cleared by the tap of a clear button that appears in the input. */
+  isClearable?: boolean;
+  /** Called when the user clears the input via the clear button. */
+  onClear?: () => void;
+}
+
+export interface RoundableProps {
+  /** Whether the input should use a fully-rounded border radius. */
+  isRound?: boolean;
+}
+
+export type InputStatus = 'default' | 'error' | 'focused';
+export type InputSize = 'sm' | 'md' | 'lg';
+
+export interface InputStyleProps {
+  /** Validation status of the input. Statuses are used to communicate error
+   * and warning states to the user through non-textual cues like colors and borders. */
+  status?: InputStatus;
+  /** Size category to use for the input. Note that not all input types allow
+   * different size categories. */
+  size?: InputSize;
+}
+export interface InputAttachmentProps {
+  /**
+   * Icon to render at the leading edge of the input. Only redesign icons should
+   * be used here. When rendering, fallbacks will be omitted.
+   */
+  leadingIcon?: ComponentType;
+  /**
+   * Icon to render at the trailing edge of the input. Only redesign icons should
+   * be used here. When rendering, fallbacks will be omitted.
+   *
+   * If the input is clearable, the trailing attachment will be replaced by a
+   * button to clear the input when it contains a value.
+   */
+  trailingIcon?: ComponentType;
+  /**
+   * Text to render at the leading edge of the input. Attachment text should
+   * generally be kept as short as possible to preserve space for the input itself.
+   *
+   * To render an icon as the leading element, use `leadingIcon` instead. If both
+   * `leadingText` and `leadingIcon` are given, only the icon will be rendered.
+   * Using both on a single input is considered invalid.
+   *
+   * Note that the type here is intentionally restricted to plain strings to avoid
+   * rendering complex content as an input attachment. For formatted text or any
+   * additional content, prefer displaying it as a `description`, `label`, or
+   * elsewhere surrounding the input rather than inside of it.
+   */
+  leadingText?: string;
+  /**
+   * Text to render at the trailing edge of the input. Attachment text should
+   * generally be kept as short as possible to preserve space for the input itself.
+   *
+   * If the input is clearable, the trailing attachment will be replaced by a
+   * button to clear the input when it contains a value.
+   *
+   * To render an icon as the leading element, use `trailingIcon` instead. If both
+   * `trailingText` and `trailingIcon` are given, only the icon will be rendered.
+   * Using both on a single input is considered invalid.
+   *
+   * Note that the type here is intentionally restricted to plain strings to avoid
+   * rendering complex content as an input attachment. For formatted text or any
+   * additional content, prefer displaying it as a `description`, `label`, or
+   * elsewhere surrounding the input rather than inside of it.
+   */
+  trailingText?: string;
+}
+
+interface ExampleInputProps
+  extends InputValueProps<string>,
+    InputStyleProps,
+    InputAttachmentProps,
+    ClearableProps,
+    RoundableProps {}
+
+export function ExampleInput(props: ExampleInputProps) {
+  return <div></div>;
+}

--- a/examples/react-next/components/ExampleComponents.tsx
+++ b/examples/react-next/components/ExampleComponents.tsx
@@ -1,4 +1,4 @@
-import {ComponentType} from 'react';
+import * as React from 'react';
 
 /**
  * React Native Input components have a broad set of properties to control them,
@@ -99,7 +99,7 @@ export interface InputAttachmentProps {
    * Icon to render at the leading edge of the input. Only redesign icons should
    * be used here. When rendering, fallbacks will be omitted.
    */
-  leadingIcon?: ComponentType;
+  leadingIcon?: React.ComponentType;
   /**
    * Icon to render at the trailing edge of the input. Only redesign icons should
    * be used here. When rendering, fallbacks will be omitted.
@@ -107,7 +107,7 @@ export interface InputAttachmentProps {
    * If the input is clearable, the trailing attachment will be replaced by a
    * button to clear the input when it contains a value.
    */
-  trailingIcon?: ComponentType;
+  trailingIcon?: React.ComponentType;
   /**
    * Text to render at the leading edge of the input. Attachment text should
    * generally be kept as short as possible to preserve space for the input itself.

--- a/packages/ts-docs-loader/index.js
+++ b/packages/ts-docs-loader/index.js
@@ -57,7 +57,6 @@ module.exports = async function docsLoader(source) {
     },
     async importModule(filePath, requestedSymbols) {
       const symbolQuery = requestedSymbols != null ? `?${requestedSymbols.join(',')}` : '';
-      console.log(`!!${thisLoaderPath}!${filePath}${symbolQuery}`);
       const result = await webpackImport(`!!${thisLoaderPath}!${filePath}${symbolQuery}`, {}).catch((e) => {
         callback(e);
       });

--- a/packages/ts-docs-loader/index.js
+++ b/packages/ts-docs-loader/index.js
@@ -44,7 +44,8 @@ module.exports = async function docsLoader(source) {
       return context;
     },
     isCurrentlyProcessing(filePath, symbols) {
-      const resource = `${filePath}?${symbols.join(',')}`;
+      const symbolQuery = symbols != null ? `?${symbols.join(',')}` : '';
+      const resource = `${filePath}${symbolQuery}`;
       return IN_PROGRESS_SET.has(resource);
     },
     async resolve(path) {
@@ -55,8 +56,9 @@ module.exports = async function docsLoader(source) {
       return resolvedPath;
     },
     async importModule(filePath, requestedSymbols) {
-      const symbolQuery = requestedSymbols.join(',');
-      const result = await webpackImport(`!!${thisLoaderPath}!${filePath}?${symbolQuery}`, {}).catch((e) => {
+      const symbolQuery = requestedSymbols != null ? `?${requestedSymbols.join(',')}` : '';
+      console.log(`!!${thisLoaderPath}!${filePath}${symbolQuery}`);
+      const result = await webpackImport(`!!${thisLoaderPath}!${filePath}${symbolQuery}`, {}).catch((e) => {
         callback(e);
       });
 

--- a/packages/ts-docs-loader/src/evaluator/README.md
+++ b/packages/ts-docs-loader/src/evaluator/README.md
@@ -1,0 +1,27 @@
+# Evaluator
+
+`ts-docs-loader` is really a partial-evaluator for TypeScript. It doesn't aim to do almost any of what typescript does, there's no checking or enforcement, and a lot of the particularly advanced features like inference and such likely won't ever be implemented, since they require tracking instantiations and other properties that are outside of the scope of documenting the declared types for a codebase.
+
+That said, there are a lot of utilities that TypeScript provides to manipulate and compose types, which _do_ affect the declared types for code, and should be documented accurately. Things like union types, using `extends` on an interface, creating unions of unions, `Omit`/`Pick`/`Exclude`, `Capitalize`/`Lowercase`/etc, and more. All of these need to be implemented to accurately determine the properties and fields of declared types. As an example of a few things:
+
+```typescript
+type StyleProps = 'className' | 'style';
+type DisallowedProps = StyleProps | 'onChange';
+
+interface BaseProps {
+  bar: string;
+  className?: string;
+  style?: Record<string, any>;
+  onChange?(): void;
+}
+
+interface Props extends Omit<BaseProps, DisallowedFields> {}
+// Without evaluating `extends`, `Omit`, or unions of unions, `Props` would
+// either end up having: no properties, all the properties of BaseProps, or
+// all of the properties other than `onChange`.
+//
+// By partially evaluating all of these operations, we get the correct result
+// of Props only having `bar` as a Prop, inherited from BaseProps.
+```
+
+This folder contains the implementations for these various operations and utilities.

--- a/packages/ts-docs-loader/src/evaluator/extends.js
+++ b/packages/ts-docs-loader/src/evaluator/extends.js
@@ -10,7 +10,7 @@
  * @param {Node} base
  * @returns {Node}
  */
-export function mergeExtensions(base) {
+module.exports = function mergeExtensions(base) {
   // If it's a proxy type, like a type alias or a generic type, just get the base type.
   if (base.type === 'application') {
     base = base.base;
@@ -55,7 +55,7 @@ export function mergeExtensions(base) {
     extends: exts,
     description: base.description,
   };
-}
+};
 
 /**
  * Merge all properties from `source` into `target`, but only if `target` does

--- a/packages/ts-docs-loader/src/evaluator/extends.js
+++ b/packages/ts-docs-loader/src/evaluator/extends.js
@@ -1,0 +1,76 @@
+/**
+ * @typedef {import('@faulty/ts-docs-node-types').PropertyNode | import('@faulty/ts-docs-node-types').MethodNode} PropertyOrMethodNode
+ * @typedef {import('@faulty/ts-docs-node-types').Node} Node
+ */
+
+/**
+ * Attempt to flatten all of the properties from all of the extended types that
+ * the interface extends into a single object.
+ *
+ * @param {Node} base
+ * @returns {Node}
+ */
+export function mergeExtensions(base) {
+  // If it's a proxy type, like a type alias or a generic type, just get the base type.
+  if (base.type === 'application') {
+    base = base.base;
+  } else if (base.type === 'alias') {
+    base = base.value;
+  }
+
+  /** @type {Record<string, PropertyOrMethodNode>} */
+  const properties = {};
+  const exts = [];
+
+  if (base.type !== 'interface') {
+    return base;
+  }
+
+  for (const ext of base.extends) {
+    if (ext == null) {
+      // temp workaround for ErrorBoundary extends React.Component which isn't being included right now for some reason
+      console.log('ext should not be null', base);
+      continue;
+    }
+
+    const merged = mergeExtensions(ext);
+    if (merged.type === 'interface') {
+      merge(properties, merged.properties, ext.id);
+    } else {
+      exts.push(merged);
+    }
+  }
+
+  merge(properties, base.properties, base.id);
+
+  return {
+    type: 'interface',
+    id: base.id,
+    name: base.name,
+    properties,
+    typeParameters: base.typeParameters,
+    // TODO: When all base classes were able to be resolved and merged, the
+    // `extends` array will be empty. Maybe it could/should still populate for
+    // additional information?
+    extends: exts,
+    description: base.description,
+  };
+}
+
+/**
+ * Merge all properties from `source` into `target`, but only if `target` does
+ * not already have a key with the same name. `inheritedFrom` will be set to
+ * the given id, unless the source node already has an inherited name set.
+ *
+ * @param {Record<string, PropertyOrMethodNode>} target
+ * @param {Record<string, PropertyOrMethodNode>} source
+ * @param {string=} inheritedFrom
+ */
+function merge(target, source, inheritedFrom) {
+  for (const key in source) {
+    target[key] = {
+      inheritedFrom,
+      ...source[key],
+    };
+  }
+}

--- a/packages/ts-docs-loader/src/evaluator/nodeResolver.js
+++ b/packages/ts-docs-loader/src/evaluator/nodeResolver.js
@@ -2,7 +2,7 @@
  * @typedef {import('@faulty/ts-docs-node-types').Asset} Asset
  * @typedef {import('@faulty/ts-docs-node-types').Node} Node
  */
-export class NodeResolver {
+module.exports = class NodeResolver {
   /**
    * @param {Record<string, Node>} nodes
    * @param {Record<string, Node>} links
@@ -90,4 +90,4 @@ export class NodeResolver {
 
     return obj;
   }
-}
+};

--- a/packages/ts-docs-loader/src/evaluator/nodeResolver.js
+++ b/packages/ts-docs-loader/src/evaluator/nodeResolver.js
@@ -1,0 +1,93 @@
+/**
+ * @typedef {import('@faulty/ts-docs-node-types').Asset} Asset
+ * @typedef {import('@faulty/ts-docs-node-types').Node} Node
+ */
+export class NodeResolver {
+  /**
+   * @param {Record<string, Node>} nodes
+   * @param {Record<string, Node>} links
+   * @param {Record<string, Asset>} dependencies
+   */
+  constructor(nodes, links, dependencies) {
+    /** @type {Record<string, Node>} */
+    this.nodes = nodes;
+    /** @type {Record<string, Node>} */
+    this.links = links;
+    /** @type {Record<string, Asset>} */
+    this.dependencies = dependencies;
+  }
+
+  /**
+   * Attempt to find the source value for the link with the given id, either
+   * within thisAsset or any of the provided dependencies.
+   *
+   * @param {string} id
+   * @returns {Node | null}
+   */
+  resolveLink(id) {
+    if (this.nodes[id] != null) {
+      return this.nodes[id];
+    }
+
+    for (const [, dep] of Object.entries(this.dependencies)) {
+      if (id in dep.links) {
+        return dep.links[id];
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Resolve all of the elements of a Union, traversing through links and type
+   * aliases to create a flat list.
+   *
+   * @param {Node} base The base element being traversed (normally a union, or other node types when recursing)
+   * @returns {Node[]}
+   */
+  resolveUnionElements(base) {
+    // If this isn't a union, just return the base element directly.
+    if (base.type !== 'union') return [base];
+
+    return base.elements.flatMap((element) => {
+      // The union can contain references to other unions, like:
+      //  type Foo = 'a' | 'b';
+      //  type Bar = Foo | 'c';
+      // When resolving `Omit<T, Bar>`, `Foo` needs to be resolved to its
+      // actual union type and then iterated.
+      const resolved = this.resolveValue(element);
+      // If the resolved value is a string, add it directly.
+      if (resolved.type === 'string' && resolved.value) return resolved;
+      // If it is _also_ a union, collect its elements as well.
+      if (resolved.type === 'union') return this.resolveUnionElements(resolved);
+      // Otherwise, just return the type
+      return resolved;
+    });
+  }
+
+  /**
+   * Resolve `obj` to a real Node from the given set of nodes.
+   * Links, applications, and aliases are all traversed.
+   *
+   * @param {Node} obj
+   * @returns {Node}
+   */
+  resolveValue(obj) {
+    if (obj.type === 'link') {
+      const resolvedLink = this.resolveLink(obj.id);
+      // If we don't know what the link points to, just return it.
+      if (resolvedLink == null) return obj;
+      return this.resolveValue(resolvedLink);
+    }
+
+    if (obj.type === 'application') {
+      return this.resolveValue(obj.base);
+    }
+
+    if (obj.type === 'alias') {
+      return this.resolveValue(obj.value);
+    }
+
+    return obj;
+  }
+}

--- a/packages/ts-docs-loader/src/evaluator/omit.js
+++ b/packages/ts-docs-loader/src/evaluator/omit.js
@@ -1,0 +1,52 @@
+/** @typedef {import('@faulty/ts-docs-node-types').Node} Node */
+/** @typedef {import('../packager').Packager} Packager */
+
+import Packager from '../packager';
+
+const OMITTABLE_TYPES = ['interface', 'object'];
+
+/**
+ * Perform TypeScript's `Omit` utility, removing the properties named by `toOmit` from `base`.
+ *
+ * @param {Packager} packager
+ * @param {Node} base
+ * @param {Node} toOmit
+ * @returns {Node}
+ */
+export function performOmit(packager, base, toOmit) {
+  base = packager.resolveValue(base);
+  toOmit = packager.resolveValue(toOmit);
+
+  if (!OMITTABLE_TYPES.includes(base.type)) return base;
+
+  const keys = new Set();
+  // If the omitted value is just a single string, add it directly
+  if (toOmit.type === 'string' && toOmit.value) {
+    keys.add(toOmit.value);
+    // If it's a union, resolve all of the elements of that union and then
+    // add them to the omitted set.
+  } else if (toOmit.type === 'union') {
+    const elements = packager.resolveUnionElements(toOmit);
+    for (const element of elements) {
+      if (element.type === 'string' && element.value != null) {
+        keys.add(element.value);
+      }
+    }
+  }
+
+  // No keys to omit, so just return the object.
+  if (keys.size === 0) return base;
+
+  // Make a new object by iterating the base and
+  const properties = {};
+  for (const key in base.properties) {
+    if (keys.has(key)) continue;
+
+    properties[key] = base.properties[key];
+  }
+
+  return {
+    ...base,
+    properties,
+  };
+}

--- a/packages/ts-docs-loader/src/evaluator/omit.js
+++ b/packages/ts-docs-loader/src/evaluator/omit.js
@@ -1,8 +1,6 @@
 /** @typedef {import('@faulty/ts-docs-node-types').Node} Node */
 /** @typedef {import('../packager').Packager} Packager */
 
-import Packager from '../packager';
-
 const OMITTABLE_TYPES = ['interface', 'object'];
 
 /**
@@ -13,7 +11,7 @@ const OMITTABLE_TYPES = ['interface', 'object'];
  * @param {Node} toOmit
  * @returns {Node}
  */
-export function performOmit(packager, base, toOmit) {
+module.exports = function performOmit(packager, base, toOmit) {
   base = packager.resolveValue(base);
   toOmit = packager.resolveValue(toOmit);
 
@@ -49,4 +47,4 @@ export function performOmit(packager, base, toOmit) {
     ...base,
     properties,
   };
-}
+};

--- a/packages/ts-docs-loader/src/evaluator/walk.js
+++ b/packages/ts-docs-loader/src/evaluator/walk.js
@@ -14,7 +14,7 @@
  *
  * @type {(obj: any, walkerFn: Walker) => any}
  */
-export function walk(obj, walkerFn) {
+module.exports = function walk(obj, walkerFn) {
   // circular is to make sure we don't traverse over an object we visited earlier in the recursion
   const circular = new Set();
 
@@ -55,4 +55,4 @@ export function walk(obj, walkerFn) {
   }
 
   return res;
-}
+};

--- a/packages/ts-docs-loader/src/evaluator/walk.js
+++ b/packages/ts-docs-loader/src/evaluator/walk.js
@@ -1,0 +1,58 @@
+/**
+ * Recurse through every key of `obj`.
+ *
+ * @typedef {import('@faulty/ts-docs-node-types').Node} Node
+ *
+ * @callback Recurser
+ * @param {Node | Node[]} obj
+ * @param {Key=} key
+ *
+ * @callback Walker
+ * @param {Node} obj
+ * @param {Key} key
+ * @param {Recurser} recurse
+ *
+ * @type {(obj: any, walkerFn: Walker) => any}
+ */
+export function walk(obj, walkerFn) {
+  // circular is to make sure we don't traverse over an object we visited earlier in the recursion
+  const circular = new Set();
+
+  /** @type {(obj: Node, k?: Key) => DocsResult}  */
+  const visit = (obj, k = null) => {
+    /** @type {Recurser} */
+    const recurse = (obj, key = k) => {
+      if (!Array.isArray(obj) && circular.has(obj)) {
+        return {
+          type: 'link',
+          id: obj.id,
+        };
+      }
+
+      if (Array.isArray(obj)) {
+        const resultArray = [];
+        obj.forEach((item, i) => (resultArray[i] = visit(item, key)));
+        return resultArray;
+      } else if (obj && typeof obj === 'object') {
+        circular.add(obj);
+        const res = {};
+        for (const key in obj) {
+          res[key] = visit(obj[key], key);
+        }
+        circular.delete(obj);
+        return res;
+      } else {
+        return obj;
+      }
+    };
+
+    return walkerFn(obj, k, recurse);
+  };
+
+  const res = {};
+  for (const k in obj) {
+    res[k] = visit(obj[k]);
+  }
+
+  return res;
+}

--- a/packages/ts-docs-loader/src/loader.js
+++ b/packages/ts-docs-loader/src/loader.js
@@ -3,7 +3,7 @@ const babel = require('@babel/parser');
 const traverse = require('@babel/traverse').default;
 const t = require('@babel/types');
 
-const packager = require('./packager');
+const Packager = require('./packager');
 const Transformer = require('./transformer');
 
 /**
@@ -55,7 +55,7 @@ module.exports = class Loader {
     const resolvedDependencies = await this.recurseDependencies(result.dependencies);
 
     const thisAsset = {id: filePath, exports: result.exportedNodes, symbols: result.symbols, links: {}};
-    return packager(thisAsset, resolvedDependencies);
+    return new Packager(thisAsset, resolvedDependencies).run();
   }
 
   /**

--- a/packages/ts-docs-loader/src/packager.js
+++ b/packages/ts-docs-loader/src/packager.js
@@ -1,10 +1,10 @@
 /* eslint-disable no-use-before-define */
 // @ts-check
 
-const {mergeExtensions} = require('./evaluator/extends');
-const {NodeResolver} = require('./evaluator/nodeResolver');
-const {performOmit} = require('./evaluator/omit');
-const {walk} = require('./evaluator/walk');
+const mergeExtensions = require('./evaluator/extends');
+const NodeResolver = require('./evaluator/nodeResolver');
+const performOmit = require('./evaluator/omit');
+const walk = require('./evaluator/walk');
 
 /**
  * @typedef {import('@faulty/ts-docs-node-types').Node} Node

--- a/packages/ts-docs-loader/test/evaluator.test.js
+++ b/packages/ts-docs-loader/test/evaluator.test.js
@@ -1,39 +1,8 @@
 import {describe, test} from '@jest/globals';
 import assert from 'node:assert/strict';
 
-import {NodeResolver} from '../src/evaluator/nodeResolver';
-import {performOmit} from '../src/evaluator/omit';
-
-/**
- * @typedef {import('@faulty/ts-docs-node-types').InterfaceNode} InterfaceNode
- * @typedef {import('@faulty/ts-docs-node-types').UnionNode} UnionNode
- */
-
-/**
- * @param {string} node
- * @param {Record<string, string>} nodes Map of property names to their type
- * @returns {InterfaceNode}
- */
-function makeInterface(name, nodes) {
-  return {
-    type: 'interface',
-    id: name,
-    name,
-    extends: [],
-    properties: Object.fromEntries(
-      Object.entries(nodes).map(([name, valueType]) => [
-        name,
-        {
-          type: 'property',
-          name,
-          value: {type: valueType},
-          optional: false,
-        },
-      ]),
-    ),
-    typeParameters: [],
-  };
-}
+import NodeResolver from '../src/evaluator/nodeResolver';
+import performOmit from '../src/evaluator/omit';
 
 function makeResolver(nodes = {}) {
   return new NodeResolver(nodes, {}, {});

--- a/packages/ts-docs-loader/test/evaluator.test.js
+++ b/packages/ts-docs-loader/test/evaluator.test.js
@@ -1,0 +1,107 @@
+import {describe, test} from '@jest/globals';
+import assert from 'node:assert/strict';
+
+import {NodeResolver} from '../src/evaluator/nodeResolver';
+import {performOmit} from '../src/evaluator/omit';
+
+/**
+ * @typedef {import('@faulty/ts-docs-node-types').InterfaceNode} InterfaceNode
+ * @typedef {import('@faulty/ts-docs-node-types').UnionNode} UnionNode
+ */
+
+/**
+ * @param {string} node
+ * @param {Record<string, string>} nodes Map of property names to their type
+ * @returns {InterfaceNode}
+ */
+function makeInterface(name, nodes) {
+  return {
+    type: 'interface',
+    id: name,
+    name,
+    extends: [],
+    properties: Object.fromEntries(
+      Object.entries(nodes).map(([name, valueType]) => [
+        name,
+        {
+          type: 'property',
+          name,
+          value: {type: valueType},
+          optional: false,
+        },
+      ]),
+    ),
+    typeParameters: [],
+  };
+}
+
+function makeResolver(nodes = {}) {
+  return new NodeResolver(nodes, {}, {});
+}
+
+const b = {
+  str: (value) => (value == null ? {type: 'string'} : {type: 'string', value}),
+  num: (value) => (value == null ? {type: 'number'} : {type: 'number', value}),
+  bool: (value) => (value == null ? {type: 'boolean'} : {type: 'boolean', value}),
+  union: (elements) => ({type: 'union', elements}),
+  alias: (name, value, typeParameters = []) => ({
+    type: 'alias',
+    id: name,
+    name,
+    value,
+    typeParameters,
+  }),
+  interface: (name, properties, extensions = [], typeParameters = []) => ({
+    type: 'interface',
+    id: name,
+    name,
+    extends: extensions,
+    properties,
+    typeParameters,
+  }),
+};
+
+describe('Omit', () => {
+  const Foo = b.interface('Foo', {
+    foo: b.str(),
+    bar: b.str(),
+    baz: b.num(),
+    onChange: b.str(),
+    onClick: b.str(),
+    className: b.str(),
+    style: b.str(),
+  });
+
+  const resolver = makeResolver({Foo});
+
+  test('removes single key from object type', () => {
+    const keys = b.union([b.str('bar')]);
+
+    const result = performOmit(resolver, Foo, keys);
+    // Assert only one element was removed
+    assert(Object.keys(result.properties).length === Object.keys(Foo.properties).length - 1);
+    assert(!('bar' in result.properties));
+  });
+
+  test('removes multiple keys from object type', () => {
+    const keys = b.union([b.str('foo'), b.str('bar')]);
+
+    const result = performOmit(resolver, Foo, keys);
+
+    assert(Object.keys(result.properties).length === Object.keys(Foo.properties).length - 2);
+    assert(!('foo' in result.properties));
+    assert(!('bar' in result.properties));
+  });
+
+  test('traverses aliases to resolve union elements', () => {
+    const HandlersAlias = b.alias('Handlers', b.union([b.str('onChange'), b.str('onClick')]));
+    const keys = b.union([HandlersAlias, b.str('bar')]);
+
+    const result = performOmit(resolver, Foo, keys);
+    // Assert only one element was removed
+    assert(Object.keys(result.properties).length === Object.keys(Foo.properties).length - 3);
+    assert(!('onChange' in result.properties));
+    assert(!('onClick' in result.properties));
+    assert(!('bar' in result.properties));
+  });
+});

--- a/packages/ts-docs-loader/test/loader.test.js
+++ b/packages/ts-docs-loader/test/loader.test.js
@@ -175,3 +175,16 @@ describe('barrel imports', () => {
     assertNodeContent(data.exports['Bar'], {id: `bar:Bar`, type: 'link'});
   });
 });
+
+test('applies names to exported declarations', async () => {
+  const loader = createTestLoader({
+    index: `
+      export const foo = () => {};
+      export const bar = 10;
+    `,
+  });
+  const data = await loader('index');
+  assert(data.exports['foo'] instanceof Object);
+  assert(data.exports['foo'].type === 'function');
+  assert(data.exports['bar'].type === 'number');
+});

--- a/packages/ts-docs-loader/test/packager.test.js
+++ b/packages/ts-docs-loader/test/packager.test.js
@@ -1,8 +1,0 @@
-import {describe, test} from '@jest/globals';
-import assert from 'node:assert/strict';
-
-import packager from '../src/packager';
-
-describe('Omit', () => {
-  test('removes single key from object type', () => {});
-});

--- a/packages/ts-docs-loader/test/packager.test.js
+++ b/packages/ts-docs-loader/test/packager.test.js
@@ -1,0 +1,8 @@
+import {describe, test} from '@jest/globals';
+import assert from 'node:assert/strict';
+
+import packager from '../src/packager';
+
+describe('Omit', () => {
+  test('removes single key from object type', () => {});
+});

--- a/packages/ts-docs-loader/test/transformer.test.js
+++ b/packages/ts-docs-loader/test/transformer.test.js
@@ -5,7 +5,7 @@ import {parse} from '@babel/parser';
 import traverse from '@babel/traverse';
 import {describe, test} from '@jest/globals';
 
-import Transformer from './transformer.js';
+import Transformer from '../src/transformer.js';
 import {assertNodeContent} from '../test/util.js';
 
 /**

--- a/packages/ts-docs-loader/test/webpack/compiler.js
+++ b/packages/ts-docs-loader/test/webpack/compiler.js
@@ -56,7 +56,9 @@ export default function compiler(entrypoint, options = {}) {
  * @returns {Record<string, string>}
  */
 export function createFixtures(files) {
-  fs.rmdirSync(FIXTURES_DIR, {recursive: true});
+  if (fs.existsSync(FIXTURES_DIR)) {
+    fs.rmdirSync(FIXTURES_DIR, {recursive: true});
+  }
   fs.mkdirSync(FIXTURES_DIR, {recursive: true});
 
   /** @type {Record<string, string>} */


### PR DESCRIPTION
`Transformer` and `Loader` have already been refactored into classes, so this moves `Packager` to also become a class. I realized later on that the class aspect didn't actually gain _too_ much here, but the bigger benefit was refactoring out the Evaluator functions so that they can be tested, and to limit the scope of `packager.js` to _just_ the packaging and not also including all of the evaluation logic as well.

More refactoring will definitely happen later (`processCode` is too long for my taste, etc.), but this is a big step to make it simpler to implement new things like `Exclude` from #1 and such.